### PR TITLE
Add support for custom wrapping for dialects

### DIFF
--- a/src/MockClient.ts
+++ b/src/MockClient.ts
@@ -63,5 +63,8 @@ export class MockClient extends knex.Client {
     const Dialect = require(`knex/lib/dialects/${resolvedClientName}/index.js`);
     const dialect = new Dialect(config);
     this.queryCompiler = dialect.queryCompiler.bind(this);
+    if (dialect.wrapIdentifierImpl) {
+      this.wrapIdentifierImpl = dialect.wrapIdentifierImpl.bind(this);
+    }
   }
 }

--- a/tests/dialects.spec.ts
+++ b/tests/dialects.spec.ts
@@ -51,6 +51,29 @@ describe('specific dialect', () => {
     });
   });
 
+  describe('mysql', () => {
+    beforeAll(() => {
+      db = knex({
+        client: MockClient,
+        dialect: 'mysql',
+      });
+      tracker = getTracker();
+    });
+
+    afterEach(() => {
+      tracker.reset();
+    });
+
+    it('should use the correct wrapper', async () => {
+      tracker.on.select('table_name').response([]);
+
+      await db('table_name');
+
+      expect(tracker.history.select).toHaveLength(1);
+      expect(tracker.history.select[0].sql).toStrictEqual('select * from `table_name`');
+    });
+  });
+
   describe('none-exists', () => {
     it('should should throw an error when passing none exists dialect', () => {
       expect(() =>


### PR DESCRIPTION
The default wrapping for identifiers is double quotes. However, the MySQL dialect uses backticks.

This changes the mock client to use the custom wrapping implementation of the dialect, if one exists.

Fixes #19.