### PR TITLE
support Error instances in simulateError

### DIFF
--- a/tests/any.spec.ts
+++ b/tests/any.spec.ts
@@ -135,6 +135,16 @@ describe('mock any statement', () => {
     await expect(db('table_name').delete().where('id', 1)).rejects.toMatchObject({
       message: expect.stringContaining(errorMessage),
     });
+  })
+
+  it('should allow to simulate error with object', async () => {
+    const error = new Error('connection error');
+    tracker.on
+      .any((rawQuery) => rawQuery.method === 'delete' && rawQuery.sql.includes('table_name'))
+      .simulateError(error);
+
+    await expect(db('table_name').delete().where('id', 1)).rejects.toBe(error);
+    await expect(db('table_name').delete().where('id', 1)).rejects.toBe(error);
   });
 
   it('should allow to simulate error once', async () => {

--- a/tests/delete.spec.ts
+++ b/tests/delete.spec.ts
@@ -132,6 +132,16 @@ describe('mock Delete statement', () => {
     await expect(db('table_name').delete().where('id', 1)).rejects.toMatchObject({
       message: expect.stringContaining('connection error'),
     });
+  })
+
+  it('should allow to simulate error with object', async () => {
+    const error = new Error('connection error');
+    tracker.on
+      .any((rawQuery) => rawQuery.method === 'delete' && rawQuery.sql.includes('table_name'))
+      .simulateError(error);
+
+    await expect(db('table_name').delete().where('id', 1)).rejects.toBe(error);
+    await expect(db('table_name').delete().where('id', 1)).rejects.toBe(error);
   });
 
   it('should allow to simulate error once', async () => {

--- a/tests/insert.spec.ts
+++ b/tests/insert.spec.ts
@@ -139,6 +139,16 @@ describe('mock Insert statement', () => {
     );
   });
 
+  it('should allow to simulate error with object', async () => {
+    const error = new Error('connection error');
+    tracker.on
+      .insert((rawQuery) => rawQuery.method === 'insert' && rawQuery.sql.includes('table_name'))
+      .simulateError(error);
+
+    await expect(db('table_name').insert([{ name: faker.name.firstName() }])).rejects.toBe(error);
+    await expect(db('table_name').insert([{ name: faker.name.firstName() }])).rejects.toBe(error);
+  });
+
   it('should allow to simulate error once', async () => {
     tracker.on
       .insert((rawQuery) => rawQuery.method === 'insert' && rawQuery.sql.includes('table_name'))

--- a/tests/select.spec.ts
+++ b/tests/select.spec.ts
@@ -148,6 +148,16 @@ describe('mock Select statement', () => {
     });
   });
 
+  it('should allow to simulate error with object', async () => {
+    const error = new Error('connection error');
+    tracker.on
+      .select((rawQuery) => rawQuery.method === 'select' && rawQuery.sql.includes('table_name'))
+      .simulateError(error);
+
+    await expect(db('table_name')).rejects.toBe(error);
+    await expect(db('table_name')).rejects.toBe(error);
+  });
+
   it('should allow to simulate error once', async () => {
     tracker.on
       .select((rawQuery) => rawQuery.method === 'select' && rawQuery.sql.includes('table_name'))

--- a/tests/update.spec.ts
+++ b/tests/update.spec.ts
@@ -140,6 +140,16 @@ describe('mock Update statement', () => {
     );
   });
 
+  it('should allow to simulate error with object', async () => {
+    const error = new Error('connection error');
+    tracker.on
+      .update((rawQuery) => rawQuery.method === 'update' && rawQuery.sql.includes('table_name'))
+      .simulateError(error);
+
+    await expect(db('table_name').update([{ name: faker.name.firstName() }])).rejects.toBe(error);
+    await expect(db('table_name').update([{ name: faker.name.firstName() }])).rejects.toBe(error);
+  });
+
   it('should allow to simulate error once', async () => {
     tracker.on
       .update((rawQuery) => rawQuery.method === 'update' && rawQuery.sql.includes('table_name'))


### PR DESCRIPTION
This allows using specific error objects.

```ts
const insertError = new DatabaseError('', 0, 'error')
insertError.code = '23505'
insertError.constraint = 'payment_identifier_unique'

tracker.on.insert('payment').simulateErrorOnce(insertError)
```