### PR TITLE
Make MockClient.tracker non-static

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,14 @@ export async function addUser(user: User): Promise<{ id }> {
 ```ts
 // my-cool-controller.spec.ts
 import { expect } from '@jest/globals';
-import knex, { Knex } from 'knex';
-import { getTracker, MockClient } from 'knex-mock-client';
+import { createTracker, MockClient } from 'knex-mock-client';
 import { faker } from '@faker-js/faker';
+import { db } from "../common/db-setup";
 
-jest.mock('../common/db-setup', () => {
+jest.mock("../common/db-setup", () => {
+  const knex = require("knex");
   return {
-    db: knex({ client: MockClient })
+    db: knex({ client: MockClient }),
   };
 });
 
@@ -52,7 +53,7 @@ describe('my-cool-controller tests', () => {
   let tracker: Tracker;
 
   beforeAll(() => {
-    tracker = getTracker();
+    tracker = createTracker(db);
   });
 
   afterEach(() => {

--- a/src/MockClient.ts
+++ b/src/MockClient.ts
@@ -4,13 +4,10 @@ import { MockConnection } from './MockConnection';
 import { Tracker, TrackerConfig } from './Tracker';
 
 export class MockClient extends knex.Client {
-  static tracker: Tracker;
   public readonly isMock = true;
 
   constructor(config: Knex.Config & { mockClient: TrackerConfig }) {
     super(config);
-
-    MockClient.tracker = new Tracker(config.mockClient);
 
     if (config.dialect) {
       this._attachDialectQueryCompiler(config);
@@ -47,7 +44,10 @@ export class MockClient extends knex.Client {
         break;
     }
 
-    return MockClient.tracker._handle(connection, { ...rawQuery, method });
+    if ('tracker' in this.config) {
+      return (this.config.tracker as Tracker)._handle(connection, { ...rawQuery, method });
+    }
+    throw new Error('Tracker not configured for knex mock client');
   }
 
   private _attachDialectQueryCompiler(config: Knex.Config<any> & { mockClient: TrackerConfig }) {

--- a/src/MockClient.ts
+++ b/src/MockClient.ts
@@ -44,8 +44,10 @@ export class MockClient extends knex.Client {
         break;
     }
 
-    if ('tracker' in this.config) {
-      return (this.config.tracker as Tracker)._handle(connection, { ...rawQuery, method });
+    // @ts-ignore (since tracker is not on the original interface)
+    const tracker = this.config.tracker as Tracker;
+    if (tracker) {
+      return tracker._handle(connection, { ...rawQuery, method });
     }
     throw new Error('Tracker not configured for knex mock client');
   }

--- a/src/Tracker.ts
+++ b/src/Tracker.ts
@@ -7,10 +7,10 @@ import { isUsingFakeTimers } from './utils';
 export type TrackerConfig = Record<string, unknown>;
 
 export type TransactionState = {
-  id: number,
-  parent?: number,
-  state: 'ongoing' | 'committed' | 'rolled back',
-  queries: RawQuery[],
+  id: number;
+  parent?: number;
+  state: 'ongoing' | 'committed' | 'rolled back';
+  queries: RawQuery[];
 };
 
 interface Handler<T = any> {
@@ -30,15 +30,16 @@ type ResponseTypes = {
 type QueryMethodType = typeof queryMethods[number];
 
 type History = Record<QueryMethodType, RawQuery[]> & {
-  transactions: TransactionState[],
-  all: RawQuery[],
+  transactions: TransactionState[];
+  all: RawQuery[];
 };
 
 export class Tracker {
   public readonly history: History = {
-    ...Object.fromEntries(
-      queryMethods.map((method) => [method, [] as RawQuery[]])
-    ) as Record<QueryMethodType, RawQuery[]>,
+    ...(Object.fromEntries(queryMethods.map((method) => [method, [] as RawQuery[]])) as Record<
+      QueryMethodType,
+      RawQuery[]
+    >),
     transactions: [],
     all: [],
   };
@@ -121,11 +122,12 @@ export class Tracker {
   private receiveTransactionCommand(connection: MockConnection, rawQuery: RawQuery): boolean {
     const txId = connection.transactionStack.peek(0);
 
-    const txState: TransactionState | undefined = txId === undefined
-      ? undefined
-      : this.history.transactions[txId];
+    const txState: TransactionState | undefined =
+      txId === undefined ? undefined : this.history.transactions[txId];
 
-    const trxCommand = transactionCommands.find((trxCommand) => rawQuery.sql.startsWith(trxCommand))
+    const trxCommand = transactionCommands.find((trxCommand) =>
+      rawQuery.sql.startsWith(trxCommand)
+    );
 
     switch (trxCommand) {
       case 'BEGIN;':
@@ -134,7 +136,7 @@ export class Tracker {
           id: this.history.transactions.length,
           state: 'ongoing',
           queries: [],
-          ...txId !== undefined && { parent: txId },
+          ...(txId !== undefined && { parent: txId }),
         };
 
         this.history.transactions.push(newTxState);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,12 @@
-import { MockClient } from './MockClient';
+import { Knex } from 'knex';
 import { Tracker } from './Tracker';
 
 export { MockClient } from './MockClient';
-export type { Tracker } from './Tracker';
+export { Tracker } from './Tracker';
 export type { RawQuery, QueryMatcher, FunctionQueryMatcher } from '../types/mock-client';
 
-export function getTracker(): Tracker {
-  if (!MockClient.tracker) {
-    throw new Error('Trying to access tracker before knex initialized');
-  }
-
-  return MockClient.tracker;
+export function createTracker(db: Knex): Tracker {
+  const tracker = new Tracker({});
+  db.client.config.tracker = tracker;
+  return tracker;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
 import { Knex } from 'knex';
-import { Tracker } from './Tracker';
+import { Tracker, TrackerConfig } from './Tracker';
 
 export { MockClient } from './MockClient';
 export { Tracker } from './Tracker';
 export type { RawQuery, QueryMatcher, FunctionQueryMatcher } from '../types/mock-client';
 
-export function createTracker(db: Knex): Tracker {
-  const tracker = new Tracker({});
+export function createTracker(db: Knex, trackerConfig: TrackerConfig = {}): Tracker {
+  const tracker = new Tracker(trackerConfig);
   db.client.config.tracker = tracker;
   return tracker;
 }

--- a/tests/all.spec.ts
+++ b/tests/all.spec.ts
@@ -1,5 +1,5 @@
 import knex, { Knex } from 'knex';
-import { getTracker, MockClient, Tracker } from '../src';
+import { createTracker, MockClient, Tracker } from '../src';
 
 describe('store all history', () => {
   let db: Knex;
@@ -9,7 +9,7 @@ describe('store all history', () => {
     db = knex({
       client: MockClient,
     });
-    tracker = getTracker();
+    tracker = createTracker(db);
   });
 
   afterEach(() => {

--- a/tests/any.spec.ts
+++ b/tests/any.spec.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker';
 import knex, { Knex } from 'knex';
-import { getTracker, MockClient, Tracker } from '../src';
+import { createTracker, MockClient, Tracker } from '../src';
 
 describe('mock any statement', () => {
   let db: Knex;
@@ -10,7 +10,7 @@ describe('mock any statement', () => {
     db = knex({
       client: MockClient,
     });
-    tracker = getTracker();
+    tracker = createTracker(db);
   });
 
   afterEach(() => {
@@ -135,7 +135,7 @@ describe('mock any statement', () => {
     await expect(db('table_name').delete().where('id', 1)).rejects.toMatchObject({
       message: expect.stringContaining(errorMessage),
     });
-  })
+  });
 
   it('should allow to simulate error with object', async () => {
     const error = new Error('connection error');

--- a/tests/common.spec.ts
+++ b/tests/common.spec.ts
@@ -1,13 +1,9 @@
 import { faker } from '@faker-js/faker';
 import knex, { Knex } from 'knex';
-import { getTracker, MockClient, Tracker } from '../src';
+import { createTracker, MockClient, Tracker } from '../src';
 import { queryMethods } from '../src/constants';
 
 describe('common behaviour', () => {
-  it('should errorMessage error when accessing tracker before initialization', async () => {
-    expect(getTracker).toThrowError('Trying to access tracker before knex initialized');
-  });
-
   describe('with db initialized', () => {
     let db: Knex;
     let tracker: Tracker;
@@ -22,7 +18,7 @@ describe('common behaviour', () => {
           database: 'DBNAME',
         },
       });
-      tracker = getTracker();
+      tracker = createTracker(db);
     });
 
     afterEach(() => {
@@ -68,7 +64,7 @@ describe('common behaviour', () => {
       db = knex({
         client: MockClient,
       });
-      tracker = getTracker();
+      tracker = createTracker(db);
     });
 
     it('should support jest fake timers', async () => {

--- a/tests/delete.spec.ts
+++ b/tests/delete.spec.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker';
 import knex, { Knex } from 'knex';
-import { getTracker, MockClient, Tracker } from '../src';
+import { createTracker, MockClient, Tracker } from '../src';
 
 describe('mock Delete statement', () => {
   let db: Knex;
@@ -10,7 +10,7 @@ describe('mock Delete statement', () => {
     db = knex({
       client: MockClient,
     });
-    tracker = getTracker();
+    tracker = createTracker(db);
   });
 
   afterEach(() => {
@@ -132,7 +132,7 @@ describe('mock Delete statement', () => {
     await expect(db('table_name').delete().where('id', 1)).rejects.toMatchObject({
       message: expect.stringContaining('connection error'),
     });
-  })
+  });
 
   it('should allow to simulate error with object', async () => {
     const error = new Error('connection error');

--- a/tests/dialects.spec.ts
+++ b/tests/dialects.spec.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker';
 import knex, { Knex } from 'knex';
-import { getTracker, MockClient, Tracker } from '../src';
+import { createTracker, MockClient, Tracker } from '../src';
 
 describe('specific dialect', () => {
   let db: Knex;
@@ -12,7 +12,7 @@ describe('specific dialect', () => {
         client: MockClient,
         dialect: 'pg',
       });
-      tracker = getTracker();
+      tracker = createTracker(db);
     });
 
     afterEach(() => {
@@ -78,7 +78,7 @@ describe('specific dialect', () => {
         client: MockClient,
         dialect: 'mysql',
       });
-      tracker = getTracker();
+      tracker = createTracker(db);
     });
 
     afterEach(() => {
@@ -101,7 +101,7 @@ describe('specific dialect', () => {
         client: MockClient,
         dialect: 'mssql',
       });
-      tracker = getTracker();
+      tracker = createTracker(db);
     });
 
     afterEach(() => {

--- a/tests/insert.spec.ts
+++ b/tests/insert.spec.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker';
 import knex, { Knex } from 'knex';
-import { getTracker, MockClient, Tracker } from '../src';
+import { createTracker, MockClient, Tracker } from '../src';
 
 describe('mock Insert statement', () => {
   let db: Knex;
@@ -10,7 +10,7 @@ describe('mock Insert statement', () => {
     db = knex({
       client: MockClient,
     });
-    tracker = getTracker();
+    tracker = createTracker(db);
   });
 
   afterEach(() => {

--- a/tests/select.spec.ts
+++ b/tests/select.spec.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker';
 import knex, { Knex } from 'knex';
-import { getTracker, MockClient, Tracker } from '../src';
+import { createTracker, MockClient, Tracker } from '../src';
 
 describe('mock Select statement', () => {
   let db: Knex;
@@ -10,7 +10,7 @@ describe('mock Select statement', () => {
     db = knex({
       client: MockClient,
     });
-    tracker = getTracker();
+    tracker = createTracker(db);
   });
 
   afterEach(() => {

--- a/tests/update.spec.ts
+++ b/tests/update.spec.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker';
 import knex, { Knex } from 'knex';
-import { getTracker, MockClient, Tracker } from '../src';
+import { createTracker, MockClient, Tracker } from '../src';
 
 describe('mock Update statement', () => {
   let db: Knex;
@@ -10,7 +10,7 @@ describe('mock Update statement', () => {
     db = knex({
       client: MockClient,
     });
-    tracker = getTracker();
+    tracker = createTracker(db);
   });
 
   afterEach(() => {


### PR DESCRIPTION
Hi! Having a static tracker causes problems when mocking multiple database connections or running tests concurrently with Ava or similar, so I made an attempt of modifying the library to make it non-static.

Of course, such a change will be a breaking one, but would you be interested in making it if it can be implemented in a somewhat reasonable way, or do you prefer to keep the library as it is?

When it comes to implementation, my first idea was to store a `tracker` instance directly on `MockClient`, but that failed for transactions because the `makeTxClient` method in knex only copies over known properties. So I then tried storing it under `config` instead. That approach seems to work fine, but is it too hackish? Let me know what you think!